### PR TITLE
Use AA tag to identify ancestral allele.

### DIFF
--- a/sofos.cc
+++ b/sofos.cc
@@ -33,8 +33,17 @@ SOFTWARE.
 
 #include <htslib/vcf.h>
 
-// bcf_get_format_* uses realloc internally, so this buffer
-// will be managed by malloc and free
+void print_usage(const char* exe, std::ostream& os) {
+    os << "Usage: " << exe << " -a alpha_param -b beta_param -n rescale_size [filepath] > output.csv\n";
+}
+
+constexpr unsigned int SOFOS_FLAG_DEFAULT=0;
+constexpr unsigned int SOFOS_FLAG_UNFOLDED=1;
+constexpr unsigned int SOFOS_FLAG_ALTREF=2;
+
+int sofos_main(const char *path, double alpha, double beta, int size, unsigned int flags=SOFOS_FLAG_DEFAULT);
+void print_usage(const char* exe, std::ostream& os);
+
 struct buffer_free_t {
     void operator()(void* ptr) const {
         free(ptr);
@@ -63,6 +72,17 @@ struct bcf_free_t {
 template<typename T>
 using buffer_t = std::unique_ptr<T[],buffer_free_t>;
 
+int get_genotypes(const bcf_hdr_t *header, bcf1_t *record,
+    buffer_t<int32_t>* buffer, int *capacity);
+int get_string(const bcf_hdr_t *header, bcf1_t *record,
+    const char *tag, buffer_t<char>* buffer, int *capacity);
+
+std::pair<std::string, std::string> timestamp();
+bool is_ref_missing(const bcf1_t* record);
+bool is_allele_missing(const char* a);
+void update_counts(double a, double b, std::vector<double> *counts);
+void update_bins(double a, double b, std::vector<double> *counts);
+
 template<typename T>
 inline
 buffer_t<T> make_buffer(std::size_t sz) {
@@ -71,6 +91,172 @@ buffer_t<T> make_buffer(std::size_t sz) {
         throw std::bad_alloc{};
     }
     return buffer_t<T>{ reinterpret_cast<T*>(p) };
+}
+
+int main(int argc, char *argv[]) {
+    try {
+        char c = 0;
+        double alpha = 1.0;
+        double beta = 1.0;
+        int size = 9;
+        bool unfolded = false;
+        bool altref = false;
+        while((c = getopt(argc, argv, "a:b:n:hufr")) != -1) {
+            switch(c) {
+            case 'a':
+                alpha = std::stod(optarg);
+                break;
+            case 'b':
+                beta = std::stod(optarg);
+                break;
+            case 'n':
+                size =  std::stoi(optarg);
+                break;
+            case 'u':
+                unfolded = true;
+                break;
+            case 'r':
+                altref = true;
+                unfolded = true;
+                break;
+            case 'f':
+                unfolded = false;
+                altref = false;
+                break;
+            case 'h':
+                print_usage(argv[0], std::cout);
+                return EXIT_SUCCESS;
+            case '?':
+                print_usage(argv[0], std::cerr);
+                return EXIT_FAILURE;                
+            };
+        }
+        const char *path = nullptr;
+        if(optind == argc) {
+            path = "-";
+        } else if(optind+1 == argc) {
+            path = argv[optind];
+        } else {
+            throw std::invalid_argument("more than one input file was specified.");
+        }
+        unsigned int flags = SOFOS_FLAG_DEFAULT;
+        if(unfolded) {
+            flags |= SOFOS_FLAG_UNFOLDED;
+            if(altref) {
+                flags |= SOFOS_FLAG_ALTREF;
+            }
+        }
+        return sofos_main(path, alpha, beta, size,flags);
+
+    } catch(std::exception &e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+    }
+    return EXIT_FAILURE;
+}
+
+int sofos_main(const char *path, double alpha, double beta, int size, unsigned int flags) {
+    assert(path != nullptr);
+    vcfFile *input_ptr = vcf_open(path,"r");
+    if(input_ptr == nullptr) {
+        throw std::runtime_error(std::string{"unable to open input file: '"} + path +"'.");
+    }
+
+    auto stamp = timestamp();
+    std::cout << "#SoFoS v2.0\n";
+    std::cout << "#date=" << stamp.first << "\n";
+    std::cout << "#epoch=" << stamp.second << "\n";
+
+    std::cout << std::setprecision(std::numeric_limits<double>::max_digits10);
+    std::cout << "#path=" << path << "\n";
+    std::cout << "#alpha=" << alpha << "\n";
+    std::cout << "#beta=" << beta << "\n";
+    std::cout << "#size=" << size << "\n";
+
+    // spacer
+    std::cout << "#\n";
+
+    std::unique_ptr<vcfFile,file_free_t> input{input_ptr};
+    std::unique_ptr<bcf_hdr_t,header_free_t> header{bcf_hdr_read(input.get())};
+    std::unique_ptr<bcf1_t,bcf_free_t> record{bcf_init()};
+    
+    size_t nsamples = bcf_hdr_nsamples(header.get());
+    int int_capacity = nsamples*4;
+    auto int_buffer = make_buffer<int32_t>(int_capacity);
+    int char_capacity = 64;
+    auto char_buffer = make_buffer<char>(char_capacity);
+
+    // A sample of N copies can have [0,N] non-ref alleles.
+    std::vector<double> posterior(size+1, 0.0);
+    std::vector<double> bins(size+1, 0.0);
+
+    size_t nsites = 0;
+
+    while(bcf_read(input.get(), header.get(), record.get()) == 0) {
+        bcf_unpack(record.get(), BCF_UN_STR);
+        //std::cerr << record.get()->rid << ":" << record.get()->pos << std::endl;
+        if(is_ref_missing(record.get())) {
+            continue;
+        }
+        // identify which allele is ancestral
+        int anc = 0;
+        if(!(flags & SOFOS_FLAG_ALTREF)) {
+            int n = get_string(header.get(), record.get(), "AA", &char_buffer, &char_capacity);
+            if(n <= 0) {
+                // missing, unknown, or empty tag
+                continue;
+            }
+            for(anc=0;anc<record.get()->n_allele;++anc) {
+                if(strcmp(char_buffer.get(), record.get()->d.allele[anc]) == 0) {
+                    break;
+                }
+            }
+        }
+        int n_ref = 0;
+        int n_alt = 0;
+
+        int n = get_genotypes(header.get(), record.get(), &int_buffer, &int_capacity);
+        int max_ploidy = n/nsamples;
+        for(int sample = 0; sample < nsamples; ++sample) {
+            int32_t *gt = int_buffer.get()+sample*max_ploidy;
+            for(int i=0; i < max_ploidy; ++i) {
+                if(gt[i] == bcf_int32_vector_end) {
+                    break;
+                }
+                if(bcf_gt_is_missing(gt[i])) {
+                    continue;
+                }
+                int allele = bcf_gt_allele(gt[i]);
+                n_ref += (allele == anc);
+                n_alt += (allele != anc);
+            }
+        }
+        int n_total = n_ref+n_alt;
+        if(n_total == 0) {
+            continue;
+        }
+        update_counts(alpha + n_alt, beta + n_ref, &posterior);            
+
+        update_bins(n_alt, n_ref, &bins);
+
+        nsites += 1;
+    }
+    // calculate prior
+    std::vector<double> prior(posterior.size(), 0.0);
+    update_counts(alpha, beta, &prior);
+
+    // output resulting scale
+    std::cout << std::setprecision(std::numeric_limits<double>::max_digits10);
+    std::cout << "Number,Prior,Observed,Posterior\n";
+    for(int i=0;i<=size;++i) {
+        std::cout << i
+                  << "," << nsites*prior[i]
+                  << "," << bins[i]
+                  << "," << posterior[i]
+                  << "\n";
+    }
+    std::cout << std::flush;
+    
+    return EXIT_SUCCESS;
 }
 
 inline
@@ -90,20 +276,44 @@ int get_genotypes(const bcf_hdr_t *header, bcf1_t *record,
 }
 
 inline
-bool is_ref_missing(const bcf1_t* record) {
-    if(record->n_allele == 0) {
+int get_string(const bcf_hdr_t *header, bcf1_t *record,
+    const char *tag, buffer_t<char>* buffer, int *capacity)
+{
+    char *p = buffer->get();
+    int n = bcf_get_info_string(header, record, tag, &p, capacity);
+    if(n == -4) {
+        throw std::bad_alloc{};
+    } else if(p != buffer->get()) {
+        // update pointer
+        buffer->release();
+        buffer->reset(p);
+    }
+    return n;
+}
+
+inline
+bool is_allele_missing(const char* a) {
+    if(a == nullptr) {
         return true;
     }
-    const char* ref = record->d.allele[0];
-    size_t len = strlen(ref);
-    if(len == 0) {
+    if(a[0] == '\0') {
         return true;
     }
-    if(len == 1 && (ref[0] == '.' || ref[0] == 'N' || ref[0] == 'n')) {
+    if((a[0] == '.' || a[0] == 'N' || a[0] == 'n') && a[1] == '\0') {
         return true;
     }
     return false;
 }
+
+inline
+bool is_ref_missing(const bcf1_t* record) {
+    if(record->n_allele == 0) {
+        return true;
+    }
+    return is_allele_missing(record->d.allele[0]);
+}
+
+
 
 std::pair<std::string, std::string> timestamp() {
     using namespace std;
@@ -134,131 +344,16 @@ void update_counts(double a, double b, std::vector<double> *counts) {
     }
 }
 
-int sofos_main(const char *path, double alpha, double beta, int size) {
-    assert(path != nullptr);
-    vcfFile *input_ptr = vcf_open(path,"r");
-    if(input_ptr == nullptr) {
-        throw std::runtime_error(std::string{"unable to open input file: '"} + path +"'.");
+void update_bins(double a, double b, std::vector<double> *bins) {
+    assert(bins != nullptr);
+    // bins are from [0,n]
+    int n = bins->size()-1;
+    double f = a/(a+b)*n;
+    int k = static_cast<int>(f+0.5);
+    if(k > n) {
+        k = n;
     }
-
-    auto stamp = timestamp();
-    std::cout << "#SoFoS v2.0\n";
-    std::cout << "#date=" << stamp.first << "\n";
-    std::cout << "#epoch=" << stamp.second << "\n";
-
-    std::cout << std::setprecision(std::numeric_limits<double>::max_digits10);
-    std::cout << "#path=" << path << "\n";
-    std::cout << "#alpha=" << alpha << "\n";
-    std::cout << "#beta=" << beta << "\n";
-    std::cout << "#size=" << size << "\n";
-
-    // spacer
-    std::cout << "#\n";
-
-    std::unique_ptr<vcfFile,file_free_t> input{input_ptr};
-    std::unique_ptr<bcf_hdr_t,header_free_t> header{bcf_hdr_read(input.get())};
-    std::unique_ptr<bcf1_t,bcf_free_t> record{bcf_init()};
-    
-    size_t nsamples = bcf_hdr_nsamples(header.get());
-    int capacity = nsamples*4;
-    auto buffer = make_buffer<int32_t>(capacity);
-
-    // A sample of N copies can have [0,N] non-ref alleles.
-    std::vector<double> counts(size+1, 0.0);
-
-    size_t nsites = 0;
-
-    while(bcf_read(input.get(), header.get(), record.get()) == 0) {
-        bcf_unpack(record.get(), BCF_UN_STR);
-
-        //std::cerr << record.get()->rid << ":" << record.get()->pos << std::endl;
-
-        if(is_ref_missing(record.get())) {
-            continue;
-        }
-        int n_ref = 0;
-        int n_alt = 0;
-
-        int n = get_genotypes(header.get(), record.get(), &buffer, &capacity);
-        int max_ploidy = n/nsamples;
-        for(int sample = 0; sample < nsamples; ++sample) {
-            int32_t *gt = buffer.get()+sample*max_ploidy;
-            for(int i=0; i < max_ploidy; ++i) {
-                if(gt[i] == bcf_int32_vector_end) {
-                    break;
-                }
-                if(bcf_gt_is_missing(gt[i])) {
-                    continue;
-                }
-                int allele = bcf_gt_allele(gt[i]);
-                n_ref += (allele == 0);
-                n_alt += (allele != 0);
-            }
-        }
-        int n_total = n_ref+n_alt;
-        // Question: Should sites with no data be included in posterior?
-        if(n_total == 0) {
-            continue;
-        }
-        update_counts(alpha + n_alt, beta + n_ref, &counts);
-        nsites += 1;
-    }
-    // calculate prior
-    std::vector<double> prior(counts.size(), 0.0);
-    update_counts(alpha, beta, &prior);
-
-    // output resulting scale
-    std::cout << std::setprecision(std::numeric_limits<double>::max_digits10);
-    std::cout << "Number,Posterior,Prior\n";
-    for(int i=0;i<=size;++i) {
-        std::cout << i << "," << counts[i] << "," << nsites*prior[i] << "\n";
-    }
-    std::cout << std::flush;
-    
-    return EXIT_SUCCESS;
+    (*bins)[k] += 1;
 }
 
-void print_usage(const char* exe, std::ostream& os) {
-    os << "Usage: " << exe << " -a alpha_param -b beta_param -n rescale_size [filepath] > output.csv\n";
-}
 
-int main(int argc, char *argv[]) {
-    try {
-        char c = 0;
-        double alpha = 1.0;
-        double beta = 1.0;
-        int size = 9;
-        while((c = getopt(argc, argv, "a:b:n:h")) != -1) {
-            switch(c) {
-            case 'a':
-                alpha = std::stod(optarg);
-                break;
-            case 'b':
-                beta = std::stod(optarg);
-                break;
-            case 'n':
-                size =  std::stoi(optarg);
-                break;
-            case 'h':
-                print_usage(argv[0], std::cout);
-                return EXIT_SUCCESS;
-            case '?':
-                print_usage(argv[0], std::cerr);
-                return EXIT_FAILURE;                
-            };
-        }
-        const char *path = nullptr;
-        if(optind == argc) {
-            path = "-";
-        } else if(optind+1 == argc) {
-            path = argv[optind];
-        } else {
-            throw std::invalid_argument("more than one input file was specified.");
-        }
-        return sofos_main(path, alpha, beta, size);
-
-    } catch(std::exception &e) {
-        std::cerr << "ERROR: " << e.what() << std::endl;
-    }
-    return EXIT_FAILURE;
-}

--- a/test/test-01.vcf
+++ b/test/test-01.vcf
@@ -1,0 +1,14 @@
+##fileformat=VCFv4.2
+##contig=<ID=1,length=10000>
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+1	1	.	A	T	.	.	AA=A	GT	0/0	0/0	0/1
+1	2	.	A	T	.	.	AA=T	GT	0/0	0/0	0/1


### PR DESCRIPTION
- Add option to use ref as ancestral allele (-r)
- Add option for folded (doesn't work) (-f, default), unfolded (works) (-u).
- Refactor code.
- Print observed distribution
- Rearrange output columns