### PR TITLE
Add include string and stdexcept

### DIFF
--- a/vcf.hpp
+++ b/vcf.hpp
@@ -26,6 +26,8 @@ SOFTWARE.
 #include <htslib/vcfutils.h>
 #include <chrono>
 #include <memory>
+#include <string>
+#include <stdexcept>
 
 // The *_free_t classes are used enable RAII on pointers created by htslib.
 namespace detail {

--- a/vcf.hpp
+++ b/vcf.hpp
@@ -24,10 +24,11 @@ SOFTWARE.
 
 #include <htslib/vcf.h>
 #include <htslib/vcfutils.h>
+
 #include <chrono>
 #include <memory>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 // The *_free_t classes are used enable RAII on pointers created by htslib.
 namespace detail {


### PR DESCRIPTION
Add includes for `string` and `stdexcept` to fix compiling errors.